### PR TITLE
Catch exception if plist malformed

### DIFF
--- a/bin/munkistaging-pkgsinfo.py
+++ b/bin/munkistaging-pkgsinfo.py
@@ -48,9 +48,13 @@ for file in args.pkgsinfo:
     if not os.path.exists(file):
         print "Skippking pkgsinfo file: %s (not found)" % file
         continue
-
-    pkgsinfo = plistlib.readPlist(file)
-
+    
+    try:
+        pkgsinfo = plistlib.readPlist(file)
+    except Exception as e:
+        print 'Unable to load file %s: %s' % (file, e)
+        continue
+    
     munkistaging = {}
     if pkgsinfo.has_key('munki_staging'):
         munkistaging = pkgsinfo['munki_staging']


### PR DESCRIPTION
Thought this should be wrapped in a try/except (has caught me out a lot with readPlist)

PS  - file is a builtin in python 2 and not the best choice for a variable name
